### PR TITLE
修改unil/camelize方法，返回驼峰首字母应该小写

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -125,9 +125,14 @@ export function camelize(target) {
         return target;
     }
     //转换为驼峰风格
-    return target.replace(rcamelize, function (match) {
+    var str = target.replace(rcamelize, function (match) {
         return match.charAt(1).toUpperCase();
     });
+    return firstLetterLower(str);
+}
+
+export function firstLetterLower(str){
+    return str.charAt(0).toLowerCase()+str.slice(1);
 }
 
 export var options = {

--- a/src/util.js
+++ b/src/util.js
@@ -18,8 +18,8 @@ export function extend(obj, props) {
     if (props) {
         for (let i in props) {
             if (props.hasOwnProperty(i)) {
-obj[i] = props[i];
-}
+                obj[i] = props[i];
+            }
         }
     }
     return obj;
@@ -131,14 +131,14 @@ export function camelize(target) {
     return firstLetterLower(str);
 }
 
-export function firstLetterLower(str){
-    return str.charAt(0).toLowerCase()+str.slice(1);
+export function firstLetterLower(str) {
+    return str.charAt(0).toLowerCase() + str.slice(1);
 }
 
 export var options = {
     beforeUnmount: noop,
     beforeRender: noop,
-    beforePatch:noop,
+    beforePatch: noop,
     afterPatch: noop,
     afterMount: noop,
     afterUpdate: noop

--- a/test/modules/util.spec.js
+++ b/test/modules/util.spec.js
@@ -5,6 +5,7 @@ import {
     toLowerCase,
     inherit,
     camelize,
+    firstLetterLower,
     getNodes,
     getChildContext,
     typeNumber
@@ -79,7 +80,15 @@ describe('util', function () {
         expect(typeof camelize).toBe('function')
         expect(camelize('aaa-bbb-ccc')).toBe('aaaBbbCcc')
         expect(camelize('aaa_bbb_ccc')).toBe('aaaBbbCcc')
+        expect(camelize('-aaa-bbb-ccc')).toBe('aaaBbbCcc')
+        expect(camelize('_aaa_bbb_ccc')).toBe('aaaBbbCcc')
         expect(camelize('')).toBe('')
+    })
+
+    it('firstLetterLower', function(){
+        expect(typeof firstLetterLower).toBe('function')
+        expect(firstLetterLower('WebkitBorderStart')).toBe('webkitBorderStart')
+        expect(firstLetterLower('')).toBe('')
     })
 
     it('getNodes', () => {


### PR DESCRIPTION
camelize方法当前返回的字符串首字母也是大写，
如果-webkit-border-start传入会返回WebkitBorderStart，
所以增加firstLetterLower方法修改首字母为小写，返回webkitBorderStart；
格式化了extend方法