### PR TITLE
fix: diffChildren 中子元素长度为1时缺少赋值vchildren

### DIFF
--- a/dist/React.js
+++ b/dist/React.js
@@ -2522,6 +2522,7 @@ function diffChildren(lastVnode, nextChildren, parentNode, context, updateQueue)
         if (parentNode.firstChild) {
             lastChildren[0]._hostNode = parentNode.firstChild;
         }
+        parentNode.vchildren = nextChildren;
         return alignVnode(lastChildren[0], nextChildren[0], lastVnode, context, updateQueue);
     }
     var maxLength = Math.max(nextLength, lastLength),

--- a/dist/ReactIE.js
+++ b/dist/ReactIE.js
@@ -2521,6 +2521,7 @@ function diffChildren(lastVnode, nextChildren, parentNode, context, updateQueue)
         if (parentNode.firstChild) {
             lastChildren[0]._hostNode = parentNode.firstChild;
         }
+        parentNode.vchildren = nextChildren;
         return alignVnode(lastChildren[0], nextChildren[0], lastVnode, context, updateQueue);
     }
     var maxLength = Math.max(nextLength, lastLength),

--- a/dist/ReactSelection.js
+++ b/dist/ReactSelection.js
@@ -2521,6 +2521,7 @@ function diffChildren(lastVnode, nextChildren, parentNode, context, updateQueue)
         if (parentNode.firstChild) {
             lastChildren[0]._hostNode = parentNode.firstChild;
         }
+        parentNode.vchildren = nextChildren;
         return alignVnode(lastChildren[0], nextChildren[0], lastVnode, context, updateQueue);
     }
     var maxLength = Math.max(nextLength, lastLength),

--- a/dist/ReactShim.js
+++ b/dist/ReactShim.js
@@ -2363,6 +2363,7 @@ function diffChildren(lastVnode, nextChildren, parentNode, context, updateQueue)
         if (parentNode.firstChild) {
             lastChildren[0]._hostNode = parentNode.firstChild;
         }
+        parentNode.vchildren = nextChildren;
         return alignVnode(lastChildren[0], nextChildren[0], lastVnode, context, updateQueue);
     }
     var maxLength = Math.max(nextLength, lastLength),

--- a/src/diff.js
+++ b/src/diff.js
@@ -420,6 +420,7 @@ function diffChildren(lastVnode, nextChildren, parentNode, context, updateQueue)
         if (parentNode.firstChild) {
             lastChildren[0]._hostNode = parentNode.firstChild;
         }
+        parentNode.vchildren = nextChildren;
         return alignVnode(lastChildren[0], nextChildren[0], lastVnode, context, updateQueue);
     }
     let maxLength = Math.max(nextLength, lastLength),


### PR DESCRIPTION
若不赋值，则在后续 diff 中会出现 ```props``` 和 ```_hostNode.vchilren``` 不一致的情况导致 diff 失败