### PR TITLE
test key before save instance

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -289,7 +289,10 @@
             Object.assign(oldInstance, newInstance);
             return oldInstance;
         }
-        instanceMap.set(getKeyForVNode(vnode), newInstance);
+        var key = getKeyForVNode(vnode);
+        if (key) {
+            instanceMap.set(key, newInstance);
+        }
         //将它存入instanceMap中
         return newInstance;
     }


### PR DESCRIPTION
例子：https://github.com/dgeibi/player ，`npm run dev`

解决 HMR 时可能导致无限循环的bug

https://github.com/RubyLouvre/anu/blob/2d135f1ed55c58e82281904de4f7ab5a630f9992/lib/devtools.js#L286

可能因为key为undefined，L286 拿到的instance不对，最终导致下面的 instance 和 child 全等，visitNonCompositeChildren 无限循环


https://github.com/RubyLouvre/anu/blob/2d135f1ed55c58e82281904de4f7ab5a630f9992/lib/devtools.js#L388-L392