### PR TITLE
transform es module to commonjs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",

--- a/packages/render/miniapp/translator/index.js
+++ b/packages/render/miniapp/translator/index.js
@@ -52,6 +52,9 @@ class Parser {
             input: path.resolve(this.path),
             plugins: [
                 resolve(),
+                commonjs({
+                    include: 'node_modules/**'
+                }),
                 rBabel({
                     exclude: ["node_modules/**"],
                     babelrc: false,
@@ -63,9 +66,7 @@ class Parser {
                         ignoreStyles
                     ]
                 }),
-                commonjs({
-
-                })
+                
             ]
         };
         this.output = outputDirPath;

--- a/packages/render/miniapp/translator/index.js
+++ b/packages/render/miniapp/translator/index.js
@@ -123,15 +123,18 @@ class Parser {
             srcPath = `nodeModules${srcPath}`;
         }
         const destPath = path.join(this.output, srcPath);
-        //类库
-        if (/reactWX/i.test(destPath)){
-            //拷贝
-            return;
-        } 
         await fs.ensureFile(path.resolve(destPath));
         const output = transform(code, sourcePath);
         const srcBasePath = id.replace(".js", "");
         const basePath = destPath.replace(".js", "");
+
+        //将transform-es2015-modules-commonjs打包成的cjs规范的库写入到build目录中
+        if(/reactWX/i.test(destPath)){
+            fs.writeFile(destPath, output.js, () => {});
+            delete output.js
+            this.outputs.push(output)
+        }
+
         //生成JS与JSON
         if (/Page|App|Component/.test(output.componentType)) {
            

--- a/packages/render/miniapp/translator/reactTranslate.js
+++ b/packages/render/miniapp/translator/reactTranslate.js
@@ -83,15 +83,6 @@ module.exports = {
     }
   },
 
-  ExportDefaultDeclaration: {
-    //小程序的模块不支持export 语句,
-    exit(path) {
-      if (path.node.declaration.type == "Identifier") {
-        path.replaceWith(helpers.exportExpr(path.node.declaration.name, true));
-      }
-    }
-  },
-
   ExportNamedDeclaration: {
     //小程序在定义
     enter() {},
@@ -157,29 +148,6 @@ module.exports = {
         path.remove();
       }
     }
-  },
-
-  ImportDeclaration(path) {
-    var href = path.node.source.value;
-    var ext = nPath.extname(href);
-    var isJS = false;
-    if (ext === "js") {
-      href = href.slice(0, -3);
-      isJS = true;
-    } else if (!ext) {
-      isJS = true;
-    }
-    var paths = path.node.specifiers.map(function(node) {
-      var importName = node.local.name;
-      var requireStatement = `var ${importName} = require("${href}")${
-        node.type == "ImportDefaultSpecifier" ? ".default" : ""
-      };`;
-      if (isJS) {
-        modules.importComponents[importName] = href;
-      }
-      return template(requireStatement)({});
-    });
-    path.replaceWithMultiple(paths);
   },
   CallExpression(path) {
     var callee = path.node.callee || Object;

--- a/packages/render/miniapp/translator/transform.js
+++ b/packages/render/miniapp/translator/transform.js
@@ -31,6 +31,7 @@ function transform(code, sourcePath) {
       //  "transform-react-jsx",
       "transform-decorators-legacy",
       "transform-object-rest-spread",
+      "transform-es2015-modules-commonjs",
       miniappPlugin
     ]
   });

--- a/scripts/build/rollup.wx.js
+++ b/scripts/build/rollup.wx.js
@@ -11,7 +11,7 @@ export default {
     input: './packages/render/miniapp/render/index.js',
     output: {
         strict: false,
-        format: 'umd',
+        format: 'es',
         exports: 'default',
         file: './dist/ReactWX.js',
         name: 'React'


### PR DESCRIPTION
1.  将reactWX打包成es模块，以便rollup解析出业务中对import(./reactWX)依赖。
   【 import React from "./reactWX" 会报错 default' is not exported by xxx/src/reactWX.js】
2. 将所有es6模块依赖打包成cjs模块，依赖babel-plugin-transform-es2015-modules-commonjs插件。
3. 写入cjs规范的reactWX.js到build中。
