### PR TITLE
解决rollup解析node_modules中cjs规范模块 && 统一打包模块规范

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",

--- a/packages/render/miniapp/translator/index.js
+++ b/packages/render/miniapp/translator/index.js
@@ -52,6 +52,9 @@ class Parser {
             input: path.resolve(this.path),
             plugins: [
                 resolve(),
+                commonjs({
+                    include: 'node_modules/**'
+                }),
                 rBabel({
                     exclude: ["node_modules/**"],
                     babelrc: false,
@@ -62,10 +65,8 @@ class Parser {
                         "transform-class-properties",
                         ignoreStyles
                     ]
-                }),
-                commonjs({
-
                 })
+                
             ]
         };
         this.output = outputDirPath;

--- a/packages/render/miniapp/translator/index.js
+++ b/packages/render/miniapp/translator/index.js
@@ -123,15 +123,18 @@ class Parser {
             srcPath = `nodeModules${srcPath}`;
         }
         const destPath = path.join(this.output, srcPath);
-        //类库
-        if (/reactWX/i.test(destPath)){
-            //拷贝
-            return;
-        } 
         await fs.ensureFile(path.resolve(destPath));
         const output = transform(code, sourcePath);
         const srcBasePath = id.replace(".js", "");
         const basePath = destPath.replace(".js", "");
+
+        //将cjs规范的reactWX库写入到build目录中
+        if(/reactWX/i.test(destPath)){
+            fs.writeFile(destPath, output.js, () => {});
+            delete output.js
+            this.outputs.push(output)
+        }
+
         //生成JS与JSON
         if (/Page|App|Component/.test(output.componentType)) {
            

--- a/packages/render/miniapp/translator/reactTranslate.js
+++ b/packages/render/miniapp/translator/reactTranslate.js
@@ -82,16 +82,6 @@ module.exports = {
       }
     }
   },
-
-  ExportDefaultDeclaration: {
-    //小程序的模块不支持export 语句,
-    exit(path) {
-      if (path.node.declaration.type == "Identifier") {
-        path.replaceWith(helpers.exportExpr(path.node.declaration.name, true));
-      }
-    }
-  },
-
   ExportNamedDeclaration: {
     //小程序在定义
     enter() {},
@@ -157,29 +147,6 @@ module.exports = {
         path.remove();
       }
     }
-  },
-
-  ImportDeclaration(path) {
-    var href = path.node.source.value;
-    var ext = nPath.extname(href);
-    var isJS = false;
-    if (ext === "js") {
-      href = href.slice(0, -3);
-      isJS = true;
-    } else if (!ext) {
-      isJS = true;
-    }
-    var paths = path.node.specifiers.map(function(node) {
-      var importName = node.local.name;
-      var requireStatement = `var ${importName} = require("${href}")${
-        node.type == "ImportDefaultSpecifier" ? ".default" : ""
-      };`;
-      if (isJS) {
-        modules.importComponents[importName] = href;
-      }
-      return template(requireStatement)({});
-    });
-    path.replaceWithMultiple(paths);
   },
   CallExpression(path) {
     var callee = path.node.callee || Object;

--- a/packages/render/miniapp/translator/transform.js
+++ b/packages/render/miniapp/translator/transform.js
@@ -31,6 +31,7 @@ function transform(code, sourcePath) {
       //  "transform-react-jsx",
       "transform-decorators-legacy",
       "transform-object-rest-spread",
+      "transform-es2015-modules-commonjs",
       miniappPlugin
     ]
   });

--- a/scripts/build/rollup.wx.js
+++ b/scripts/build/rollup.wx.js
@@ -11,7 +11,7 @@ export default {
     input: './packages/render/miniapp/render/index.js',
     output: {
         strict: false,
-        format: 'umd',
+        format: 'es',
         exports: 'default',
         file: './dist/ReactWX.js',
         name: 'React'


### PR DESCRIPTION
### 统一打包模块规范
1.将reactWX打包成es模块，业务中直接import该模块，统一成es模块便于rollup分析相关依赖。
2.将所有es模块通过babel对应插件打包成cjs规范模块，以供小程序解析。