### PR TITLE
fixed webpack watch trigger multiple builds

### DIFF
--- a/packages/cli/packages/template/src/pages/demo/view/index/index.js
+++ b/packages/cli/packages/template/src/pages/demo/view/index/index.js
@@ -45,5 +45,4 @@ class P extends React.Component {
         );
     }
 }
-Page(React.createPage(P, "pages/demo/view/index/index"));
 export default P;

--- a/packages/cli/packages/template/src/pages/demo/view/movableView/index.js
+++ b/packages/cli/packages/template/src/pages/demo/view/movableView/index.js
@@ -100,5 +100,4 @@ class P extends React.Component {
         );
     }
 }
-Page(React.createPage(P, "pages/demo/view/movableView/index"));
 export default P;

--- a/packages/cli/packages/translator/index.js
+++ b/packages/cli/packages/translator/index.js
@@ -44,6 +44,7 @@ class Parser {
     constructor(entry){
         this.entry = entry;
         this.compiler = null;
+        this.statsHash = '';
         this.config = {
             entry: path.resolve(this.entry),
             module: {
@@ -79,6 +80,9 @@ class Parser {
 
     }
     startCodeGen(stats){
+        //webpack watch 可能触发多次 build https://webpack.js.org/api/node/#watching
+        if(this.statsHash === stats.hash) return;
+        this.statsHash = stats.hash;
         let dependencies = stats.compilation.fileDependencies;
         dependencies.forEach((file)=>{
             if(!/node_modules/g.test(file)){


### PR DESCRIPTION
1.通过hash来判断是否需要重新构建，解决webpack watch可能触发多次build问题。