### PR TITLE
提高getLocation函数的ie8兼容性

### DIFF
--- a/packages/router/history.js
+++ b/packages/router/history.js
@@ -5,14 +5,19 @@ import {
 export var modeObject = {}
 //伪造一个Location对象
 function getLocation(source) {
-    return {
-        ...source.location,
+    const location = {
         getPath() {
             return modeObject.value === "hash" ? this.hash.slice(1) : this.pathname
         },
         state: source.history.state,
         key: (source.history.state && source.history.state.key) || "initial"
     };
+    for (const key in source.location) {
+        if (!Object.hasOwnProperty.call(source.location, key)) {
+            location[key] = source.location[key];
+        }
+    }
+    return location;
 }
 
 //伪造一个History对象

--- a/packages/router/history.js
+++ b/packages/router/history.js
@@ -13,7 +13,7 @@ function getLocation(source) {
         key: (source.history.state && source.history.state.key) || "initial"
     };
     for (const key in source.location) {
-        if (!Object.hasOwnProperty.call(source.location, key)) {
+        if (Object.prototype.hasOwnProperty.call(source.location, key)) {
             location[key] = source.location[key];
         }
     }


### PR DESCRIPTION
getLocation函数内容转义后为`return Object.assign({}, source.location, {/*略*/});`。
当使用babel-polyfill提供Object.assign语法支持时，会报错：`Object.prototype.propertyIsEnumerable: 'this' 不是 JavaScript 对象`。
使用for循环替换Object.assign进行属性复制。