### PR TITLE
[bugfix] fix SVG attribute value bug when it's zero

### DIFF
--- a/packages/render/dom/props.js
+++ b/packages/render/dom/props.js
@@ -270,7 +270,7 @@ export let actionStrategy = {
             // 将xlinkHref 转换为 xlink:href
             dom[method + "NS"](NAMESPACE[prefix], nameRes.name, val || "");
         } else {
-            dom[method](nameRes, val || "");
+            dom[method](nameRes, typeNumber(val) !== 3 && !val ? "" : val);
         }
     },
     booleanAttr: function(dom, name, val) {


### PR DESCRIPTION
```svg
<svg>
    <rect with="1" height="1" x={0} y={0} />
</svg>
```
svg attributes value have number type, and  `0 || ''` will return `''`, then browser will throw error

```
ReactIE.js:1669 Error: <rect> attribute x: Unexpected end of attribute. Expected length, "".
```

![image](https://user-images.githubusercontent.com/424491/47017854-ef460880-d185-11e8-8379-86e7095e0f1b.png)
