### PR TITLE
 快应用底栏高度 与支付宝保持视觉一致

### DIFF
--- a/packages/cli/packages/quickHelpers/PageWrapper.ux
+++ b/packages/cli/packages/quickHelpers/PageWrapper.ux
@@ -30,7 +30,7 @@
       position: fixed;
       bottom: 0;
       width: 100%;
-      height: 150px;
+      height: 110px;
     }
   
     .tabBar .tab {


### PR DESCRIPTION
 快应用底栏高度 与支付宝保持视觉一致