### PR TITLE
Fix vnode

### DIFF
--- a/dist/React/server.js
+++ b/dist/React/server.js
@@ -479,6 +479,7 @@
     };
     var _marked = regeneratorRuntime.mark(renderVNodeGen);
     function renderVNode(vnode, context) {
+        if(!vnode) return '';
         var _vnode = vnode,
             tag = _vnode.tag,
             type = _vnode.type,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "anujs",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "a React16-compact mini framework",
 	"main": "dist/React.js",
 	"scripts": {


### PR DESCRIPTION
在使用next 7.0.1，anujs替代了react会时候发现，vnode会有空的情况，如果直接报数据不合法会造成整个页面无法渲染。