### PR TITLE
fix: 阿里小程序中app.json的字段没有正确改变的问题

### DIFF
--- a/packages/cli/packages/aliHelpers/configName.js
+++ b/packages/cli/packages/aliHelpers/configName.js
@@ -54,7 +54,7 @@ module.exports = function mapConfigName(config) {
     if (tabBar) {
         tabBar = config.tabBar;
         swapProperty(tabBar, barNames);
-        if (Array.isArray(tabBar.list)) {
+        if (Array.isArray(tabBar.items)) {
             tabBar.items.forEach(function(tab) {
                 swapProperty(tab, tabNames);
             });


### PR DESCRIPTION
由于阿里小程序的tabBar中的配置叫做 `items`，
所以判断条件应该为 `Array.isArray(tabBar.items)`