### PR TITLE
修复寻找插入点问题

### DIFF
--- a/packages/fiber/insertPoint.js
+++ b/packages/fiber/insertPoint.js
@@ -72,11 +72,11 @@ function downward(fiber) {
         if (fiber.tag > 3) {
             return fiber;
         }
-        if (fiber.forward) {
-            found = forward(fiber);
-            if (found) {
-                return found;
-            }
-        }
+        // if (fiber.forward) {
+        //     found = forward(fiber);
+        //     if (found) {
+        //         return found;
+        //     }
+        // }
     }
 }


### PR DESCRIPTION
现在更新时，fiber算法寻找插入点有问题，在寻找子fiber时，不应该寻找子fiber的forward节点，不然会出现插入点错误，点击B，导致更新，会把B Fiber更新class为error后面，代码如下：
```javascript
var container = document.getElementById('root');
  class A extends React.Component{
    state = {
      time: 19860219
    }
    render(){
      return <div>
        <C>
          <div class ="error">123</div>
          <D></D>  
        </C>
        <B/>
      </div>
    }
  
  }
  class B extends React.Component{
    state = {
      time: 19860219
    }
    onClick(){
      this.setState({
        time: new Date - 0
      })
    }
    render(){
      return <div onClick={
            this.onClick.bind(this)
      }>
        {this.state.time}
      </div>
    }
  }
    class C extends React.Component{
      render(){
        return this.props.children
      }
    }
    class D extends React.Component{
      render(){
        return <div>
          D
        </div>
      }
    }
  



  ReactDOM.render(<A />, container)
  
```

