### PR TITLE
修改嵌套循环下对应的key值不正确的问题

### DIFF
--- a/packages/cli/packages/wxHelpers/createLogicHelper.js
+++ b/packages/cli/packages/wxHelpers/createLogicHelper.js
@@ -84,11 +84,13 @@ module.exports = function createLogicHelper(prefix, keyName, hasDefaultKey){
             var forExpr = '(' + fn.params[1].name + ',' + fn.params[0].name + ') in ' + parseExpr(callee.object).slice(2, -2);
             attrs.push(createAttribute('for', forExpr));
         }
-       
-        if (modules.key) {
+
+        var key = Array.isArray(modules.key) === true ? modules.key[modules.key.length - 1] : void 666;
+
+        if (key && key.split('.')[0] === fn.params[0].name) {
             //快应用不生成key
-            prefix &&  attrs.push(createAttribute(keyName, utils.genKey(modules.key)));
-            modules.key = null;
+            prefix && attrs.push(createAttribute(keyName, utils.genKey(key)));
+            modules.key.pop();
         } else if (hasDefaultKey) {
             attrs.push(createAttribute(keyName, '*this'));
         }

--- a/packages/cli/packages/wxHelpers/wxml.js
+++ b/packages/cli/packages/wxHelpers/wxml.js
@@ -114,7 +114,10 @@ let visitor = {
                     value = fixKey;
                 }
             }
-            modules.key = value;
+            if (Array.isArray(modules.key) === false) {
+                modules.key = []
+            }
+            modules.key.push(value);
             astPath.remove();
             return;
         }


### PR DESCRIPTION
多重嵌套循环的情况下生成的block key不正确

当前情况下, 如果嵌套循环, 只有一个循环能取到key, 其他都是*this

![image](https://user-images.githubusercontent.com/24601357/60635988-4dffff00-9e47-11e9-9104-f2ba567819f8.png)

![image](https://user-images.githubusercontent.com/24601357/60635991-51938600-9e47-11e9-998a-ada030a08397.png)
