### PR TITLE
fix: useEffect trigger when dependency array not change

### DIFF
--- a/packages/fiber/dispatcher.js
+++ b/packages/fiber/dispatcher.js
@@ -58,7 +58,7 @@ export function useCallbackImpl(create, deps, isMemo) {//ok
         if (prevState) {
             let prevInputs = prevState[1];
             if (areHookInputsEqual(nextInputs, prevInputs)) {
-                return prevState[0];
+                return;
             }
         }
 


### PR DESCRIPTION
useCallbackImpl return create callback when prevDeps equal to nextDeps, and then callback will be added to effect update list array and will be triggered then. This is not compatible with React, I think it should not return callback when them equals, then there has nothing happens.

close https://github.com/RubyLouvre/anu/issues/1067 when pull requrest merged.