### PR TITLE
React.api.createInnerAudioContext()

### DIFF
--- a/packages/cli/templates/qunar/source/pages/apis/index/index.js
+++ b/packages/cli/templates/qunar/source/pages/apis/index/index.js
@@ -343,6 +343,12 @@ class P extends React.Component {
           >
             <text>路由</text>
           </div>
+          <div
+            onClick={this.gotoSome.bind(this, '/pages/apis/innerAudio/index')}
+            class="anu-item"
+          >
+            <text>innerAudio</text>
+          </div>
           
         </div>
       </div>

--- a/packages/cli/templates/qunar/source/pages/apis/innerAudio/index.js
+++ b/packages/cli/templates/qunar/source/pages/apis/innerAudio/index.js
@@ -1,0 +1,200 @@
+/* eslint-disable no-console */
+import React from '@react';
+import './index.scss';
+
+const EVENT = [
+    'onPlay',
+    'onCanplay',
+    'onPause',
+    // 'onStop',
+    'onEnded',
+    'onTimeUpdate',
+    'onError',
+    'onWaiting',
+    'onSeeking',
+    'onSeeked'
+];
+
+class P extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            audioIns: {},
+            btnDisable: true,
+            audio: {
+                src:
+                    'http://ws.stream.qqmusic.qq.com/M500001VfvsJ21xFqb.mp3?guid=ffffffff82def4af4b12b3cd9337d5e7&uin=346897220&vkey=6292F51E1E384E06DCBDC9AB7C49FD713D632D313AC4858BACB8DDD29067D3C601481D36E62053BF8DFEAF74C0A5CCFADD6471160CAF3E6A&fromtag=46',
+                name: '此时此刻',
+                author: '许巍',
+                loop: false,
+                controls: false
+            }
+        };
+
+        this.create = this.create.bind(this);
+        this.destroy = this.destroy.bind(this);
+    }
+
+    timer = null;
+
+    componentDidMount() {}
+
+    componentWillUnmount() {
+        this.clearTimer();
+    }
+
+    clearTimer() {
+        clearInterval(this.timer);
+    }
+
+    create() {
+        const audio = React.api.createInnerAudioContext();
+        console.log('audio:::', audio);
+
+        audio.src =
+            'http://ws.stream.qqmusic.qq.com/M500001VfvsJ21xFqb.mp3?guid=ffffffff82def4af4b12b3cd9337d5e7&uin=346897220&vkey=6292F51E1E384E06DCBDC9AB7C49FD713D632D313AC4858BACB8DDD29067D3C601481D36E62053BF8DFEAF74C0A5CCFADD6471160CAF3E6A&fromtag=46';
+        audio.autoplay = true;
+        audio.startTime = 59;
+        this.audioEl = audio;
+        this.setState({ btnDisable: false });
+
+        this.timer = setInterval(() => {
+            const audioIns = {
+                buffered: audio.buffered,
+                currentTime: audio.currentTime,
+                paused: audio.paused,
+                duration: audio.duration
+            };
+            this.setState({ audioIns });
+        }, 2000);
+    }
+
+    destroy() {
+        if (this.state.btnDisable) return;
+        this.audioEl.destroy();
+        this.setState({ btnDisable: true, audioIns: {} });
+
+        this.clearTimer();
+    }
+
+    setVolume(value) {
+        console.log('setVolume:', value);
+        if (this.state.btnDisable) return;
+        this.audioEl.volume = value;
+        console.log('after: setVolume:', this.audioEl.volume);
+    }
+
+    seek(pos) {
+        this.audioEl.seek(pos);
+    }
+
+    onPlay(e) {
+        console.log('onPlay:e:', e);
+    }
+
+    onCanplay(e) {
+        console.log('canPlay:e:', e);
+    }
+
+    onPause(e) {
+        console.log('onPause:e:', e);
+    }
+
+    onError(e) {
+        console.log('onError:e:', e);
+    }
+
+    onEnded(e) {
+        console.log('onEnded:e:', e);
+    }
+
+    onTimeUpdate(e) {
+        console.log('onTimeUpdate:e:', e);
+    }
+
+    onWaiting(e) {
+        console.log('onWaiting:e:', e);
+    }
+
+    render() {
+        return (
+            <div>
+                <div className="tip">去控制台的 console 查看更多</div>
+                <div className="tip">如果create失败，请尝试把react核心库更新到最新版</div>
+                {!this.state.btnDisable ? (
+                    <div>
+                        <div>paused: {String(this.state.audioIns.paused)}</div>
+                        <div>duration: {this.state.audioIns.duration}s(秒)</div>
+                        <div>currentTime: {this.state.audioIns.currentTime}s(秒)</div>
+                        <div>buffered: {this.state.audioIns.buffered}s(秒)</div>
+                    </div>
+                ) : null}
+                <div className="row">
+                    <button disabled={!this.state.btnDisable} onClick={this.create}>
+                        create
+                    </button>
+                    <button disabled={this.state.btnDisable} onClick={this.destroy}>
+                        destroy
+                    </button>
+                </div>
+                <div className="row">
+                    <button
+                        disabled={this.state.btnDisable}
+                        onClick={() => !this.state.btnDisable && this.audioEl.play()}>
+                        play
+                    </button>
+                    <button
+                        disabled={this.state.btnDisable}
+                        onClick={() => !this.state.btnDisable && this.audioEl.pause()}>
+                        pause
+                    </button>
+                    <button
+                        disabled={this.state.btnDisable}
+                        onClick={() => !this.state.btnDisable && this.audioEl.stop()}>
+                        stop
+                    </button>
+                </div>
+                <div className="row">
+                    {[0, 0.1, 0.3, 0.5, 0.8, 1].map((v, idx) => (
+                        <button
+                            onClick={() => this.setVolume(v)}
+                            key={idx}
+                            disabled={this.state.btnDisable}>
+                            {`${v * 100}%`}
+                        </button>
+                    ))}
+                </div>
+                <div className="row">
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map((v, idx) => (
+                        <button
+                            onClick={() => this.seek(v * 30)}
+                            key={idx}
+                            disabled={this.state.btnDisable}>
+                            {`${v * 30}s`}
+                        </button>
+                    ))}
+                </div>
+                {EVENT.map((evt, idx) => {
+                    const off = evt.replace('on', 'off');
+                    const bd = this.state.btnDisable;
+                    return (
+                        <div className="row" key={idx}>
+                            <button
+                                disabled={bd}
+                                onClick={() => !bd && this.audioEl[evt](this[evt])}>
+                                {evt}
+                            </button>
+                            <button
+                                disabled={bd}
+                                onClick={() => !bd && this.audioEl[off](this[evt])}>
+                                {off}
+                            </button>
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+}
+
+export default P;

--- a/packages/cli/templates/qunar/source/pages/apis/innerAudio/index.scss
+++ b/packages/cli/templates/qunar/source/pages/apis/innerAudio/index.scss
@@ -1,0 +1,10 @@
+.row {
+    display: flex;
+    flex-direction: row;
+}
+
+.tip {
+    color: red;
+    font-size: 36rpx;
+    text-align: center;
+}

--- a/packages/render/miniapp/apiForH5/audio.js
+++ b/packages/render/miniapp/apiForH5/audio.js
@@ -278,8 +278,6 @@ class InnerAudioContext {
 
 export default {
     createInnerAudioContext(id, opts = {}) {
-        // eslint-disable-next-line no-console
-        console.log('%ccreateInnerAudioContext::xxx::', 'color:red;font-size:21pt;');
         return new InnerAudioContext(id, opts);
     }
 };

--- a/packages/render/miniapp/apiForH5/audio.js
+++ b/packages/render/miniapp/apiForH5/audio.js
@@ -1,0 +1,285 @@
+/**
+ * changelog
+ * 添加 React.api.createInnerAudioContext() 方法，使用方法同步微信小程序
+ *    因为 iOS Safari 的限制，导致 volume 设置不生效(Android和PC目前正常)
+ *    h5 audio 的原生 api 没有 stop 方法和事件，可以使用 pause() 加上 seek(0) 代替(即: 暂停 加上 跳转到开头)
+ */
+
+class InnerAudioContext {
+    constructor(id, opts) {
+        this.audioEl = this.init(id, opts);
+        this._isPaused = false;
+    }
+
+    set src(value) {
+        this.audioEl.src = value;
+    }
+    set startTime(value) {
+        this.audioEl.mozCurrentSampleOffset = value;
+    }
+    set autoplay(value) {
+        this.audioEl.autoplay = value;
+    }
+    set loop(value) {
+        this.audioEl.loop = value;
+    }
+    set obeyMuteSwitch(value) {
+        this.audioEl.muted = value;
+    }
+    set volume(value) {
+        value = value >= 1 ? 1 : value <= 0 ? 0 : value;
+        this.audioEl.volume = parseFloat(value);
+    }
+
+    get duration() {
+        let v = '';
+        if (this.audioEl.src) {
+            v = this.audioEl.duration;
+        }
+        return v;
+    }
+    get currentTime() {
+        let v = '';
+        if (this.audioEl.src) {
+            v = this.audioEl.currentTime;
+        }
+        return v;
+    }
+    get paused() {
+        return this._isPaused;
+    }
+    get buffered() {
+        const b = this.audioEl.buffered;
+        return b.end(0);
+    }
+    get volume() {
+        return this.audioEl.volume;
+    }
+
+    init(id) {
+        let audioElement = document.createElement('AUDIO');
+        if (id) {
+            audioElement = document.getElementById(id);
+        } else {
+            audioElement.id = Date.now();
+            audioElement.style.position = 'absolute';
+            audioElement.style.top = '-200px';
+            audioElement.preload = 'metadata';
+            audioElement.controls = false;
+            // test
+            // audioElement.style.top = '60px';
+            // audioElement.style.right = '0px';
+            // audioElement.controls = true;
+            // test End
+            document.body.appendChild(audioElement);
+        }
+        return audioElement;
+    }
+
+    /**
+     * 暂停
+     */
+    play() {
+        this._isPaused = false;
+        this.audioEl.play();
+    }
+
+    /**
+     * 暂停
+     */
+    pause() {
+        this._isPaused = true;
+        this.audioEl.pause();
+    }
+
+    /**
+     * 停止。停止后的音频再播放会从头开始播放。
+     */
+    // stop() {
+    //     this.pause();
+    //     this.seek(0);
+    // }
+
+    /**
+     * 销毁当前实例
+     */
+    destroy() {
+        this.audioEl.remove();
+    }
+
+    /**
+     * 跳转到指定位置
+     * @param {number} pos
+     */
+    seek(pos) {
+        this.audioEl.currentTime = pos;
+    }
+
+    /**
+     * 监听音频进入可以播放状态的事件。但不保证后面可以流畅播放
+     * @param {function} callback 回调函数
+     */
+    onCanplay(callback) {
+        this.audioEl.addEventListener('canplay', callback);
+    }
+
+    /**
+     * 取消监听音频进入可以播放状态的事件
+     * @param {function} callback 回调函数
+     */
+    offCanplay(callback) {
+        this.audioEl.removeEventListener('canplay', callback);
+    }
+
+    /**
+     * 监听音频播放事件
+     * @param {function} callback 回调函数
+     */
+    onPlay(callback) {
+        this.audioEl.addEventListener('play', callback);
+    }
+
+    /**
+     * 取消监听音频播放事件
+     * @param {function} callback 回调函数
+     */
+    offPlay(callback) {
+        this.audioEl.removeEventListener('play', callback);
+    }
+
+    /**
+     * 监听音频暂停事件
+     * @param {function} callback 回调函数
+     */
+    onPause(callback) {
+        this.audioEl.addEventListener('pause', callback);
+    }
+
+    /**
+     * 取消监听音频暂停事件
+     * @param {function} callback 回调函数
+     */
+    offPause(callback) {
+        this.audioEl.removeEventListener('pause', callback);
+    }
+
+    /**
+     * 监听音频停止事件
+     * @param {function} callback 回调函数
+     */
+    // onStop(callback) {
+    //     this.audioEl.addEventListener('ended', callback);
+    // }
+
+    /**
+     * 取消监听音频停止事件
+     * @param {function} callback 回调函数
+     */
+    // offStop(callback) {
+    //     this.audioEl.removeEventListener('ended', callback);
+    // }
+
+    /**
+     * 监听音频自然播放至结束的事件
+     * @param {function} callback 回调函数
+     */
+    onEnded(callback) {
+        this.audioEl.addEventListener('ended', callback);
+    }
+
+    /**
+     * 取消监听音频自然播放至结束的事件
+     * @param {function} callback 回调函数
+     */
+    offEnded(callback) {
+        this.audioEl.removeEventListener('ended', callback);
+    }
+
+    /**
+     * 监听音频播放进度更新事件
+     * @param {function} callback 回调函数
+     */
+    onTimeUpdate(callback) {
+        this.audioEl.addEventListener('timeupdate', callback);
+    }
+
+    /**
+     * 取消监听音频播放进度更新事件
+     * @param {function} callback 回调函数
+     */
+    offTimeUpdate(callback) {
+        this.audioEl.removeEventListener('timeupdate', callback);
+    }
+
+    /**
+     * 监听音频播放错误事件
+     * @param {function} callback 回调函数
+     */
+    onError(callback) {
+        this.audioEl.addEventListener('error', callback);
+    }
+
+    /**
+     * 取消监听音频播放错误事件
+     * @param {function} callback 回调函数
+     */
+    offError(callback) {
+        this.audioEl.removeEventListener('error', callback);
+    }
+
+    /**
+     * 监听音频加载中事件。当音频因为数据不足，需要停下来加载时会触发
+     * @param {function} callback 回调函数
+     */
+    onWaiting(callback) {
+        this.audioEl.addEventListener('waiting', callback);
+    }
+
+    /**
+     * 取消监听音频加载中事件。当音频因为数据不足，需要停下来加载时会触发
+     * @param {function} callback 回调函数
+     */
+    offWaiting(callback) {
+        this.audioEl.removeEventListener('waiting', callback);
+    }
+
+    /**
+     * 监听音频进行跳转操作的事件
+     * @param {function} callback 回调函数
+     */
+    onSeeking(callback) {
+        this.audioEl.addEventListener('seeking', callback);
+    }
+
+    /**
+     * 取消监听音频进行跳转操作的事件
+     * @param {function} callback 回调函数
+     */
+    offSeeking(callback) {
+        this.audioEl.removeEventListener('seeking', callback);
+    }
+
+    /**
+     * 监听音频完成跳转操作的事件
+     * @param {function} callback 回调函数
+     */
+    onSeeked(callback) {
+        this.audioEl.addEventListener('seeked', callback);
+    }
+
+    /**
+     * 取消监听音频完成跳转操作的事件
+     * @param {function} callback 回调函数
+     */
+    offSeeked(callback) {
+        this.audioEl.removeEventListener('seeked', callback);
+    }
+}
+
+export default {
+    createInnerAudioContext(id, opts = {}) {
+        // eslint-disable-next-line no-console
+        console.log('%ccreateInnerAudioContext::xxx::', 'color:red;font-size:21pt;');
+        return new InnerAudioContext(id, opts);
+    }
+};


### PR DESCRIPTION
添加 React.api.createInnerAudioContext() 方法，使用方法同步微信小程序
- 因为 iOS Safari 的限制，volume 设置不生效(Android和PC目前正常)
- h5 audio 的原生 api 没有 stop 方法和事件，可以使用 pause() 加上 seek(0) 代替(即: 暂停 加上 跳转到开头)